### PR TITLE
Added lualine theme

### DIFF
--- a/lua/lualine/themes/everblush.lua
+++ b/lua/lualine/themes/everblush.lua
@@ -1,0 +1,37 @@
+local colors = require('colorschemes.everblush').get_palette()
+
+local everblush = {}
+
+everblush.normal = {
+  a = { bg = colors.magenta, fg = colors.bg },
+  b = { bg = colors.black, fg = colors.cyan },
+  c = { bg = colors.bg, fg = colors.fg },
+}
+
+everblush.insert = {
+  a = { bg = colors.green, fg = colors.bg },
+  b = { bg = colors.black, fg = colors.green },
+}
+
+everblush.command = {
+  a = { bg = colors.blue, fg = colors.bg },
+  b = { bg = colors.black, fg = colors.blue },
+}
+
+everblush.visual = {
+  a = { bg = colors.yellow, fg = colors.bg },
+  b = { bg = colors.black, fg = colors.yellow },
+}
+
+everblush.replace = {
+  a = { bg = colors.red, fg = colors.bg },
+  b = { bg = colors.black, fg = colors.red },
+}
+
+everblush.inactive = {
+  a = { bg = colors.bg, fg = colors.cyan },
+  b = { bg = colors.bg, fg = colors.fg, gui = "bold" },
+  c = { bg = colors.bg, fg = colors.fg },
+}
+
+return everblush


### PR DESCRIPTION
I create a lualine port for everblush.vim, extracted from my neovim distribution [nvcodark](https://github.com/AlphaTechnolog/nvcodark) that has some ideas that you can implement in everblush.vim, but it's writted in lua :v anyway, it are good :D

I will post screenshots of nvcodark, were you can view the style that I implement in the nvcodark everblush port :D

## NvCoDark look with everblush
![everblush-nvcodark](https://github.com/AlphaTechnolog/nvcodark/raw/main/.misc/showcase/everblush-nvcodark.png)

> Note: NvCoDark uses base everblush.vim for base highlights, I only add highlights for missing plugins like nvim-tree or telescope, etc...

## Screenshots with my dotfiles (bspwm and chadwm):

### Bspwm
![everblush-bspwm](https://github.com/AlphaTechnolog/dotfiles/raw/main/.misc/showcase/everblush.png)

### Chadwm
![everblush-chadwm](https://github.com/AlphaTechnolog/dotfiles/raw/main/.misc/showcase/chadwm/everblush-chadwm.png)