### PR TITLE
Using local palette in lualine theme instead of an inexistent file

### DIFF
--- a/lua/lualine/themes/everblush.lua
+++ b/lua/lualine/themes/everblush.lua
@@ -1,6 +1,17 @@
-local colors = require('colorschemes.everblush').get_palette()
-
 local everblush = {}
+local colors = {
+  fg = '#dadada',
+  bg = '#181f21',
+  black = '#22292b',
+  darkbg = '#151b1d',
+  red = '#e06e6e',
+  green = '#8ccf7e',
+  yellow = '#e5c76b',
+  blue = '#67b0e8',
+  magenta = '#c47fd5',
+  cyan = '#6cd0ca',
+  white = '#b3b9b8',
+}
 
 everblush.normal = {
   a = { bg = colors.magenta, fg = colors.bg },


### PR DESCRIPTION
The lualine pull request (#19), have a problem, I copy complete the file from my nvcodark lualine port for everblush, and it import some files that are inexistent in everblush.vim bootstrap, but exists in nvcodark bootstrap, with this changes, the problem is solved, I put all necesary functions in the same file (`lua/lualine/themes/everblush.vim`) Sorry for the problems